### PR TITLE
Drag Drop Improvements

### DIFF
--- a/OoTR Zbank Ripper/Drop Rom Here.bat
+++ b/OoTR Zbank Ripper/Drop Rom Here.bat
@@ -1,2 +1,4 @@
-.\bankripper.py %1 --I 50  --o %1
+cd /D "%~dp0"
+
+.\bankripper.py "%~1" --I 50  --o "%~nx1"
 pause

--- a/SampleCreationTools/DropYourWavHere.bat
+++ b/SampleCreationTools/DropYourWavHere.bat
@@ -1,2 +1,24 @@
-.\z64audio.exe --i %1 --I 50  --o %1.bin
+@echo off
+cd /D "%~dp0"
+
+:Loop
+
+z64audio.exe --i %1 --I 50 --o %~n1.bin
+
+REM Rename output config.toml to unique name matching wav input file
+ren config.toml "%~n1.toml"
+ren "%~n1.book.bin" "%~n1.book"
+ren "%~n1.loopbook.bin" "%~n1.loopbook"
+
+REM // Move all files to output subfolder
+if not exist output\ md output
+
+move "%~n1.toml" output
+move "%~n1.vadpcm.bin" output
+
+
+REM // Handle multiple arguments
+SHIFT
+IF "%~1" NEQ "" (GOTO Loop)
+
 pause


### PR DESCRIPTION
Sharing some improvements to the .bat files I made during my use of these tools:
- Allow Drag and Drop of multiple custom samples from anywhere on disk all at once in the Sample Creation Tools .bat file
- Allow Drag and Drop of a ROM from anywhere on disk in the ZBank ripper

Generated files will now be placed into an /output/ subfolder, excluding the <sample>.book and <sample>.loopbook, as those need to be run with their appropriate .py file.